### PR TITLE
Fix make location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/target/
+/.idea/
+/lein-assemble.iml

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject com.chartbeat.cljbeat/lein-assemble "0.1.4"
+(defproject com.chartbeat.cljbeat/lein-assemble "0.1.5"
   :description "A leiningen plugin to do the job of maven assembly"
   :url "https://github.com/chartbeat-labs/lein-assembly"
   :license {:name "BSD 3 Clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[me.raynes/fs "1.4.6"]
                  [stencil "0.5.0" :exclusions [org.clojure/core.cache]]
-                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojure "1.8.0"]
                  [org.apache.ant/ant "1.9.4"]]
   :deploy-repositories [["releases" :clojars]]
   :signing {:gpg-key "F0903068"}

--- a/src/leiningen/assemble.clj
+++ b/src/leiningen/assemble.clj
@@ -12,8 +12,8 @@
   (:import (java.io ByteArrayOutputStream File FileOutputStream)
            (java.util.zip GZIPOutputStream ZipOutputStream ZipEntry)
            (org.apache.tools.tar TarEntry TarOutputStream)
-	   (java.util.regex Matcher))
-  )
+     (java.util.regex Matcher)))
+
 
 (defn make-file-path
   [root & rest]
@@ -35,7 +35,7 @@
 
 (defn- remove-leading [path]
   (.replaceAll path(str "^" (Matcher/quoteReplacement File/separator))
-                             ""))
+                   ""))
 
 ;; these are from the lein-tar plugin. Respect.
 (defn- add-file [tar path f]
@@ -130,7 +130,7 @@
   [location]
   (lein/info "Creating: " location)
   (delete-if-exists location)
-  (fs/mkdir location))
+  (fs/mkdirs location))
 
 (defn stache-filename
   "run the filename through the mustache filter"
@@ -145,9 +145,9 @@
        (lein/debug "Copying: " src " -> " dest)
        (if (fs/directory? src)
          (fs/copy-dir src dest)
-         (fs/copy src dest)
-         )
-       )
+         (fs/copy src dest)))
+
+
      (do
        (lein/debug "Copying with transformations: " src " -> " dest)
        (with-open [w (clojure.java.io/writer dest)]
@@ -217,8 +217,8 @@
                                :zip ".zip"
                                :tar ".tar"
                                :gz ".gz"
-                               :tgz ".tgz"
-                               ))
+                               :tgz ".tgz"))
+
         tar-file   (io/file dest (str name ".tar"))]
     (when (or (= format :tar) (= format :tgz))
                                         ; make a tar file first (or last)

--- a/test/leiningen/assemble_test.clj
+++ b/test/leiningen/assemble_test.clj
@@ -1,0 +1,10 @@
+(ns leiningen.assemble-test
+  (:require [clojure.test :refer :all]
+            [leiningen.assemble :refer :all]
+            [me.raynes.fs :as fs]))
+
+
+(deftest do-make-location-test
+  (do
+    (do-make-location "target/assembly/123")
+    (is (= true (fs/exists? "target/assembly/123")))))


### PR DESCRIPTION
Now the assemble plugin creates the target and other parent directories that may not exist.